### PR TITLE
Add 06_portfolio binary_quadratic_programming OMMX converter

### DIFF
--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/constants.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/constants.py
@@ -1,0 +1,14 @@
+"""Fixed dimensions shared by model.py, dat_reader.py, and sol_reader.py.
+
+The values come from parameter_u3_c10.zpl of the original QOBLIB repository:
+the number of units per asset and position (ub), the position signs
+(long/short), and the binary expansion widths of the two slack variables
+(CS1, CS2).
+"""
+
+from typing import Final
+
+NUM_UNITS: Final[int] = 3
+NUM_SIGNS: Final[int] = 2
+NUM_Y_SLACKS: Final[int] = 4
+NUM_S_SLACKS: Final[int] = 7

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/constants.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/constants.py
@@ -2,13 +2,14 @@
 
 The values come from parameter_u3_c10.zpl of the original QOBLIB repository:
 the number of units per asset and position (ub), the position signs
-(long/short), and the binary expansion widths of the two slack variables
-(CS1, CS2).
+(long/short; index l -> sign TAU[l]), and the binary expansion widths of
+the two slack variables (CS1, CS2).
 """
 
 from typing import Final
 
 NUM_UNITS: Final[int] = 3
-NUM_SIGNS: Final[int] = 2
+TAU: Final[tuple[int, int]] = (1, -1)
+NUM_SIGNS: Final[int] = len(TAU)
 NUM_Y_SLACKS: Final[int] = 4
 NUM_S_SLACKS: Final[int] = 7

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
@@ -1,0 +1,158 @@
+import gzip
+import math
+import os
+from fractions import Fraction
+
+import numpy as np
+
+# Model parameters fixed in parameter_u3_c10.zpl of the original QOBLIB repository.
+CASH = 1_000_000
+UNIT = 100_000
+DELTA = Fraction("0.001")
+NU = Fraction("0.0001")
+RHO = Fraction("0.000025")
+UB = 3
+C = CASH // UNIT
+
+# b_tot for each number of assets, defined in gen_archive.sh of the original
+# QOBLIB repository.
+B_BY_ASSETS = {10: 4, 50: 20, 200: 50, 400: 100}
+
+
+def zimpl_round(value: Fraction) -> int:
+    """Round half away from zero, as ZIMPL's round() does.
+
+    ZIMPL computes with exact rationals (GMP), so the coefficients must be
+    derived with exact rational arithmetic before rounding; float64 errors of
+    a single ulp around .5 boundaries would otherwise flip the result.
+    """
+    if value >= 0:
+        return math.floor(value + Fraction(1, 2))
+    return math.ceil(value - Fraction(1, 2))
+
+
+def _read_data_lines(filepath: str) -> list[list[str]]:
+    """Read non-empty, non-comment lines of a (possibly gzipped) text file."""
+    opener = gzip.open if filepath.endswith(".gz") else open
+    rows = []
+    with opener(filepath, "rt", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            rows.append(line.split())
+    return rows
+
+
+def read_portfolio_instance(
+    instance_dir: str, lam: Fraction, num_assets: int
+) -> tuple[dict, list[str]]:
+    """Read a QOBLIB portfolio instance directory and build the instance data.
+
+    The directory must contain `stock_prices.txt.gz` and
+    `covariance_matrices.txt.gz` (price and covariance data per day), as in the
+    `instances/po_aXXX_tXX_*` directories of the original QOBLIB repository.
+
+    Args:
+        instance_dir: Path to the instance directory.
+        lam: Risk weight lambda of the objective function (exact rational).
+        num_assets: Number of assets (used to look up the asset limit B).
+
+    Returns:
+        A tuple of:
+        - instance data dict for the placeholders of `model.create_problem`,
+        - list of stock symbols in file order (defines the asset index i).
+    """
+    price_rows = _read_data_lines(os.path.join(instance_dir, "stock_prices.txt.gz"))
+    cov_rows = _read_data_lines(
+        os.path.join(instance_dir, "covariance_matrices.txt.gz")
+    )
+
+    # Symbols in order of first appearance; day indices must be 0..T-1.
+    symbols: list[str] = []
+    days: set[int] = set()
+    raw_p: dict[tuple[str, int], Fraction] = {}
+    for day, symbol, price in price_rows:
+        day = int(day)
+        days.add(day)
+        if symbol not in symbols:
+            symbols.append(symbol)
+        raw_p[(symbol, day)] = Fraction(price)
+
+    if len(symbols) != num_assets:
+        raise ValueError(
+            f"Number of symbols in {instance_dir} is {len(symbols)}, "
+            f"but expected {num_assets}."
+        )
+    if num_assets not in B_BY_ASSETS:
+        raise ValueError(
+            f"Unhandled number of assets ({num_assets}). "
+            f"Choose from {sorted(B_BY_ASSETS)}."
+        )
+
+    A = len(symbols)
+    T = len(days)
+    if sorted(days) != list(range(T)):
+        raise ValueError(f"Day indices in {instance_dir} are not contiguous from 0.")
+    sym_idx = {s: i for i, s in enumerate(symbols)}
+
+    # One unit is UNIT / raw_p[s, 0] shares of stock s; p is the exact rational
+    # price of one unit of stock s on day t.
+    p = [[raw_p[(s, t)] * UNIT / raw_p[(s, 0)] for t in range(T)] for s in symbols]
+
+    cov = {
+        (sym_idx[s1], sym_idx[s2], int(day)): Fraction(value)
+        for day, s1, s2, value in cov_rows
+    }
+
+    tau = (1, -1)
+
+    # risk[i, li, j, lj, t] = round(lam * tau_li * tau_lj * cov[i,j,t] * p[i,t] * p[j,t])
+    risk = np.zeros((A, 2, A, 2, T))
+    if lam != 0:
+        for (i, j, t), cov_value in cov.items():
+            value = zimpl_round(lam * cov_value * p[i][t] * p[j][t])
+            risk[i, 0, j, 0, t] = value
+            risk[i, 1, j, 1, t] = value
+            # Opposite signs: round(-q) == -round(q) for half away from zero.
+            risk[i, 0, j, 1, t] = -value
+            risk[i, 1, j, 0, t] = -value
+
+    # ret[i, l, t] = round(tau_l * (p[i,t+1] - p[i,t])); zero-padded at t = T-1.
+    ret = np.zeros((A, 2, T))
+    for i in range(A):
+        for t in range(T - 1):
+            for l in range(2):
+                ret[i, l, t] = zimpl_round(tau[l] * (p[i][t + 1] - p[i][t]))
+
+    # Transaction costs round(DELTA * p), split into the rebalancing coupling
+    # between consecutive days (intermediate days only) and the single-day
+    # costs of the first day (initial buy) and the last day (liquidation).
+    tcost = np.array([[zimpl_round(DELTA * p[i][t]) for t in range(T)] for i in range(A)])
+    tcost_pair = np.zeros((A, T))
+    tcost_pair[:, 1:-1] = tcost[:, 1:-1]
+    tcost_single = np.zeros((A, T))
+    tcost_single[:, 0] = tcost[:, 0]
+    tcost_single[:, -1] = tcost[:, -1]
+
+    short_cost = np.array(
+        [[zimpl_round(RHO * p[i][t]) for t in range(T)] for i in range(A)]
+    )
+    cash_interest = np.array([zimpl_round(NU * UNIT * 2**k) for k in range(4)])
+
+    instance_data = {
+        "A": A,
+        "T": T,
+        "risk": risk,
+        "ret": ret,
+        "tcost_pair": tcost_pair,
+        "tcost_single": tcost_single,
+        "short_cost": short_cost.astype(np.float64),
+        "cash_interest": cash_interest.astype(np.float64),
+        "tau": np.array(tau, dtype=np.float64),
+        "pow2_y": 2.0 ** np.arange(4),
+        "pow2_s": 2.0 ** np.arange(7),
+        "C": float(C),
+        "B": float(B_BY_ASSETS[num_assets]),
+    }
+    return instance_data, symbols

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
@@ -13,6 +13,10 @@ NU = Fraction("0.0001")
 RHO = Fraction("0.000025")
 UB = 3
 C = CASH // UNIT
+# Binary expansion widths of the two slack variables (CS1, CS2 in
+# parameter_u3_c10.zpl); kept in sync with model.py / sol_reader.py.
+NUM_Y_SLACKS = 4
+NUM_S_SLACKS = 7
 
 # b_tot for each number of assets, defined in gen_archive.sh of the original
 # QOBLIB repository.
@@ -138,7 +142,9 @@ def read_portfolio_instance(
     short_cost = np.array(
         [[zimpl_round(RHO * p[i][t]) for t in range(T)] for i in range(A)]
     )
-    cash_interest = np.array([zimpl_round(NU * UNIT * 2**k) for k in range(4)])
+    cash_interest = np.array(
+        [zimpl_round(NU * UNIT * 2**k) for k in range(NUM_Y_SLACKS)]
+    )
 
     instance_data = {
         "A": A,
@@ -150,8 +156,8 @@ def read_portfolio_instance(
         "short_cost": short_cost.astype(np.float64),
         "cash_interest": cash_interest.astype(np.float64),
         "tau": np.array(tau, dtype=np.float64),
-        "pow2_y": 2.0 ** np.arange(4),
-        "pow2_s": 2.0 ** np.arange(7),
+        "pow2_y": 2.0 ** np.arange(NUM_Y_SLACKS),
+        "pow2_s": 2.0 ** np.arange(NUM_S_SLACKS),
         "C": float(C),
         "B": float(B_BY_ASSETS[num_assets]),
     }

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
@@ -5,7 +5,7 @@ from fractions import Fraction
 
 import numpy as np
 
-from constants import NUM_S_SLACKS, NUM_Y_SLACKS
+from constants import NUM_S_SLACKS, NUM_SIGNS, NUM_Y_SLACKS, TAU
 
 # Model parameters fixed in parameter_u3_c10.zpl of the original QOBLIB repository.
 CASH = 1_000_000
@@ -45,29 +45,11 @@ def _read_data_lines(filepath: str) -> list[list[str]]:
     return rows
 
 
-def read_portfolio_instance(
-    instance_dir: str, lam: Fraction, num_assets: int
-) -> tuple[dict, list[str]]:
-    """Read a QOBLIB portfolio instance directory and build the instance data.
-
-    The directory must contain `stock_prices.txt.gz` and
-    `covariance_matrices.txt.gz` (price and covariance data per day), as in the
-    `instances/po_aXXX_tXX_*` directories of the original QOBLIB repository.
-
-    Args:
-        instance_dir: Path to the instance directory.
-        lam: Risk weight lambda of the objective function (exact rational).
-        num_assets: Number of assets (used to look up the asset limit B).
-
-    Returns:
-        A tuple of:
-        - instance data dict for the placeholders of `model.create_problem`,
-        - list of stock symbols in file order (defines the asset index i).
-    """
+def read_stock_prices(
+    instance_dir: str, num_assets: int
+) -> tuple[list[str], list[list[Fraction]]]:
+    """Read stock prices and derive exact per-unit prices."""
     price_rows = _read_data_lines(os.path.join(instance_dir, "stock_prices.txt.gz"))
-    cov_rows = _read_data_lines(
-        os.path.join(instance_dir, "covariance_matrices.txt.gz")
-    )
 
     # Symbols in order of first appearance; day indices must be 0..T-1.
     symbols: list[str] = []
@@ -96,7 +78,6 @@ def read_portfolio_instance(
             f"Choose from {sorted(B_BY_ASSETS)}."
         )
 
-    A = len(symbols)
     T = len(days)
     if sorted(days) != list(range(T)):
         raise ValueError(f"Day indices in {instance_dir} are not contiguous from 0.")
@@ -106,12 +87,21 @@ def read_portfolio_instance(
             f"Missing stock price entries in {instance_dir}: {missing[:3]}"
             + (" ..." if len(missing) > 3 else "")
         )
-    sym_idx = {s: i for i, s in enumerate(symbols)}
-
     # One unit is UNIT / raw_p[s, 0] shares of stock s; p is the exact rational
     # price of one unit of stock s on day t.
     p = [[raw_p[(s, t)] * UNIT / raw_p[(s, 0)] for t in range(T)] for s in symbols]
+    return symbols, p
 
+
+def read_covariance_matrix(
+    instance_dir: str, symbols: list[str], num_periods: int
+) -> dict[tuple[int, int, int], Fraction]:
+    """Read the full covariance matrix for each day."""
+    cov_rows = _read_data_lines(
+        os.path.join(instance_dir, "covariance_matrices.txt.gz")
+    )
+    sym_idx = {s: i for i, s in enumerate(symbols)}
+    num_assets = len(symbols)
     cov: dict[tuple[int, int, int], Fraction] = {}
     for row in cov_rows:
         if len(row) != 4:
@@ -125,43 +115,56 @@ def read_portfolio_instance(
                 f"Unknown symbol {unknown!r} in covariance data of {instance_dir}."
             )
         day = int(day_str)
-        if not 0 <= day < T:
+        if not 0 <= day < num_periods:
             raise ValueError(
-                f"Covariance day index {day} in {instance_dir} is outside 0..{T - 1}."
+                f"Covariance day index {day} in {instance_dir} is outside "
+                f"0..{num_periods - 1}."
             )
         cov[(sym_idx[s1], sym_idx[s2], day)] = Fraction(value)
     # The upstream files contain the full A x A matrix for every day; a partial
     # file would otherwise silently leave risk coefficients at zero.
-    if len(cov) != A * A * T:
+    if len(cov) != num_assets * num_assets * num_periods:
         raise ValueError(
             f"Covariance data in {instance_dir} has {len(cov)} unique entries, "
-            f"but expected {A * A * T} (full matrix for all days)."
+            f"but expected {num_assets * num_assets * num_periods} "
+            f"(full matrix for all days)."
         )
+    return cov
 
-    tau = (1, -1)
 
-    # risk[i, li, j, lj, t] = round(lam * tau_li * tau_lj * cov[i,j,t] * p[i,t] * p[j,t])
-    risk = np.zeros((A, 2, A, 2, T))
+def compute_coefficients(
+    lam: Fraction,
+    p: list[list[Fraction]],
+    cov: dict[tuple[int, int, int], Fraction],
+    num_assets: int,
+) -> dict:
+    """Build the numerical arrays used by model.create_problem."""
+    A = len(p)
+    T = len(p[0]) if p else 0
+    # risk[i, li, j, lj, t] =
+    # round(lam * tau_li * tau_lj * cov[i,j,t] * p[i,t] * p[j,t])
+    risk = np.zeros((A, NUM_SIGNS, A, NUM_SIGNS, T))
     if lam != 0:
         for (i, j, t), cov_value in cov.items():
-            value = zimpl_round(lam * cov_value * p[i][t] * p[j][t])
-            risk[i, 0, j, 0, t] = value
-            risk[i, 1, j, 1, t] = value
-            # Opposite signs: round(-q) == -round(q) for half away from zero.
-            risk[i, 0, j, 1, t] = -value
-            risk[i, 1, j, 0, t] = -value
+            for li, tau_i in enumerate(TAU):
+                for lj, tau_j in enumerate(TAU):
+                    risk[i, li, j, lj, t] = zimpl_round(
+                        lam * tau_i * tau_j * cov_value * p[i][t] * p[j][t]
+                    )
 
     # ret[i, l, t] = round(tau_l * (p[i,t+1] - p[i,t])); zero-padded at t = T-1.
-    ret = np.zeros((A, 2, T))
+    ret = np.zeros((A, NUM_SIGNS, T))
     for i in range(A):
         for t in range(T - 1):
-            for l in range(2):
-                ret[i, l, t] = zimpl_round(tau[l] * (p[i][t + 1] - p[i][t]))
+            for l, tau_l in enumerate(TAU):
+                ret[i, l, t] = zimpl_round(tau_l * (p[i][t + 1] - p[i][t]))
 
     # Transaction costs round(DELTA * p), split into the rebalancing coupling
     # between consecutive days (intermediate days only) and the single-day
     # costs of the first day (initial buy) and the last day (liquidation).
-    tcost = np.array([[zimpl_round(DELTA * p[i][t]) for t in range(T)] for i in range(A)])
+    tcost = np.array(
+        [[zimpl_round(DELTA * p[i][t]) for t in range(T)] for i in range(A)]
+    )
     tcost_pair = np.zeros((A, T))
     tcost_pair[:, 1:-1] = tcost[:, 1:-1]
     tcost_single = np.zeros((A, T))
@@ -184,10 +187,35 @@ def read_portfolio_instance(
         "tcost_single": tcost_single,
         "short_cost": short_cost.astype(np.float64),
         "cash_interest": cash_interest.astype(np.float64),
-        "tau": np.array(tau, dtype=np.float64),
+        "tau": np.array(TAU, dtype=np.float64),
         "pow2_y": 2.0 ** np.arange(NUM_Y_SLACKS),
         "pow2_s": 2.0 ** np.arange(NUM_S_SLACKS),
         "C": float(C),
         "B": float(B_BY_ASSETS[num_assets]),
     }
+    return instance_data
+
+
+def read_portfolio_instance(
+    instance_dir: str, lam: Fraction, num_assets: int
+) -> tuple[dict, list[str]]:
+    """Read a QOBLIB portfolio instance directory and build the instance data.
+
+    The directory must contain `stock_prices.txt.gz` and
+    `covariance_matrices.txt.gz` (price and covariance data per day), as in the
+    `instances/po_aXXX_tXX_*` directories of the original QOBLIB repository.
+
+    Args:
+        instance_dir: Path to the instance directory.
+        lam: Risk weight lambda of the objective function (exact rational).
+        num_assets: Number of assets (used to look up the asset limit B).
+
+    Returns:
+        A tuple of:
+        - instance data dict for the placeholders of `model.create_problem`,
+        - list of stock symbols in file order (defines the asset index i).
+    """
+    symbols, p = read_stock_prices(instance_dir, num_assets)
+    cov = read_covariance_matrix(instance_dir, symbols, len(p[0]))
+    instance_data = compute_coefficients(lam, p, cov, num_assets)
     return instance_data, symbols

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
@@ -76,8 +76,13 @@ def read_portfolio_instance(
     symbols: list[str] = []
     days: set[int] = set()
     raw_p: dict[tuple[str, int], Fraction] = {}
-    for day, symbol, price in price_rows:
-        day = int(day)
+    for row in price_rows:
+        if len(row) != 3:
+            raise ValueError(
+                f"Malformed stock price line in {instance_dir}: {' '.join(row)!r}"
+            )
+        day_str, symbol, price = row
+        day = int(day_str)
         days.add(day)
         if symbol not in symbols:
             symbols.append(symbol)
@@ -98,16 +103,43 @@ def read_portfolio_instance(
     T = len(days)
     if sorted(days) != list(range(T)):
         raise ValueError(f"Day indices in {instance_dir} are not contiguous from 0.")
+    missing = [(s, t) for s in symbols for t in range(T) if (s, t) not in raw_p]
+    if missing:
+        raise ValueError(
+            f"Missing stock price entries in {instance_dir}: {missing[:3]}"
+            + (" ..." if len(missing) > 3 else "")
+        )
     sym_idx = {s: i for i, s in enumerate(symbols)}
 
     # One unit is UNIT / raw_p[s, 0] shares of stock s; p is the exact rational
     # price of one unit of stock s on day t.
     p = [[raw_p[(s, t)] * UNIT / raw_p[(s, 0)] for t in range(T)] for s in symbols]
 
-    cov = {
-        (sym_idx[s1], sym_idx[s2], int(day)): Fraction(value)
-        for day, s1, s2, value in cov_rows
-    }
+    cov: dict[tuple[int, int, int], Fraction] = {}
+    for row in cov_rows:
+        if len(row) != 4:
+            raise ValueError(
+                f"Malformed covariance line in {instance_dir}: {' '.join(row)!r}"
+            )
+        day_str, s1, s2, value = row
+        if s1 not in sym_idx or s2 not in sym_idx:
+            unknown = s1 if s1 not in sym_idx else s2
+            raise ValueError(
+                f"Unknown symbol {unknown!r} in covariance data of {instance_dir}."
+            )
+        day = int(day_str)
+        if not 0 <= day < T:
+            raise ValueError(
+                f"Covariance day index {day} in {instance_dir} is outside 0..{T - 1}."
+            )
+        cov[(sym_idx[s1], sym_idx[s2], day)] = Fraction(value)
+    # The upstream files contain the full A x A matrix for every day; a partial
+    # file would otherwise silently leave risk coefficients at zero.
+    if len(cov) != A * A * T:
+        raise ValueError(
+            f"Covariance data in {instance_dir} has {len(cov)} unique entries, "
+            f"but expected {A * A * T} (full matrix for all days)."
+        )
 
     tau = (1, -1)
 

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/dat_reader.py
@@ -5,18 +5,15 @@ from fractions import Fraction
 
 import numpy as np
 
+from constants import NUM_S_SLACKS, NUM_Y_SLACKS
+
 # Model parameters fixed in parameter_u3_c10.zpl of the original QOBLIB repository.
 CASH = 1_000_000
 UNIT = 100_000
 DELTA = Fraction("0.001")
 NU = Fraction("0.0001")
 RHO = Fraction("0.000025")
-UB = 3
 C = CASH // UNIT
-# Binary expansion widths of the two slack variables (CS1, CS2 in
-# parameter_u3_c10.zpl); kept in sync with model.py / sol_reader.py.
-NUM_Y_SLACKS = 4
-NUM_S_SLACKS = 7
 
 # b_tot for each number of assets, defined in gen_archive.sh of the original
 # QOBLIB repository.

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
@@ -1,12 +1,6 @@
 import jijmodeling as jm
 
-# Fixed dimensions from parameter_u3_c10.zpl of the original QOBLIB repository:
-# units per asset and position (ub), position signs (long/short), and the
-# binary expansion widths of the two slack variables (CS1, CS2).
-NUM_UNITS = 3
-NUM_SIGNS = 2
-NUM_Y_SLACKS = 4
-NUM_S_SLACKS = 7
+from constants import NUM_S_SLACKS, NUM_SIGNS, NUM_UNITS, NUM_Y_SLACKS
 
 
 @jm.Problem.define(

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
@@ -39,7 +39,9 @@ def _portfolio_bqp(problem: jm.DecoratedProblem):
     - x[i, m, l, t]: hold the m-th unit of asset i with position tau[l]
                      (l = 0: long, l = 1: short) on day t
     - y[k, t]:       binary expansion slack of the capital limit constraint
-    - s[c, t]:       binary expansion slack of the asset limit constraint
+    - s2[c, t]:      binary expansion slack of the asset limit constraint
+                     (same name as the original ZIMPL model; OMMX subscripts
+                     are 0-based)
     """
     # Placeholders for data from file
     A = problem.Length("A", description="Number of assets")
@@ -60,7 +62,7 @@ def _portfolio_bqp(problem: jm.DecoratedProblem):
     )
     tau = problem.Float("tau", ndim=1, description="Position sign (1: long, -1: short)")
     pow2_y = problem.Float("pow2_y", ndim=1, description="Powers of two for y slack")
-    pow2_s = problem.Float("pow2_s", ndim=1, description="Powers of two for s slack")
+    pow2_s = problem.Float("pow2_s", ndim=1, description="Powers of two for s2 slack")
     C = problem.Float("C", description="Capital limit in units")
     B = problem.Float("B", description="Maximum number of assets")
 
@@ -69,7 +71,9 @@ def _portfolio_bqp(problem: jm.DecoratedProblem):
         "x", shape=(A, NUM_UNITS, NUM_SIGNS, T), description="Variable x"
     )
     y = problem.BinaryVar("y", shape=(NUM_Y_SLACKS, T), description="Slack variable y")
-    s = problem.BinaryVar("s", shape=(NUM_S_SLACKS, T), description="Slack variable s")
+    s2 = problem.BinaryVar(
+        "s2", shape=(NUM_S_SLACKS, T), description="Slack variable s2"
+    )
 
     # Risk term
     objective = jm.sum(
@@ -147,7 +151,7 @@ def _portfolio_bqp(problem: jm.DecoratedProblem):
                 for m in jm.range(NUM_UNITS)
                 for l in jm.range(NUM_SIGNS)
             )
-            + jm.sum(pow2_s[c] * s[c, t] for c in jm.range(NUM_S_SLACKS))
+            + jm.sum(pow2_s[c] * s2[c, t] for c in jm.range(NUM_S_SLACKS))
             == B
             for t in T
         ),

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
@@ -9,7 +9,9 @@ NUM_Y_SLACKS = 4
 NUM_S_SLACKS = 7
 
 
-@jm.Problem.define("Portfolio_binary_quadratic", sense=jm.ProblemSense.MINIMIZE)
+@jm.Problem.define(
+    "Portfolio_binary_quadratic_programming", sense=jm.ProblemSense.MINIMIZE
+)
 def _portfolio_bqp(problem: jm.DecoratedProblem):
     """QOBLIB portfolio binary quadratic programming (BQP) model.
 

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/model.py
@@ -1,0 +1,165 @@
+import jijmodeling as jm
+
+# Fixed dimensions from parameter_u3_c10.zpl of the original QOBLIB repository:
+# units per asset and position (ub), position signs (long/short), and the
+# binary expansion widths of the two slack variables (CS1, CS2).
+NUM_UNITS = 3
+NUM_SIGNS = 2
+NUM_Y_SLACKS = 4
+NUM_S_SLACKS = 7
+
+
+@jm.Problem.define("Portfolio_binary_quadratic", sense=jm.ProblemSense.MINIMIZE)
+def _portfolio_bqp(problem: jm.DecoratedProblem):
+    """QOBLIB portfolio binary quadratic programming (BQP) model.
+
+    This is the constrained formulation of the multi-period portfolio
+    optimization problem (06-portfolio) defined in
+    models/binary_quadratic_programming/bqp_u3_c10.zpl of the original QOBLIB
+    repository.  The capital limit and the number-of-assets limit are kept as
+    hard equality constraints (the unconstrained_quadratic_optimization model
+    folds them into the objective as penalty terms instead).
+
+    All cost coefficients are precomputed (including ZIMPL's `round()`) by
+    `dat_reader.read_portfolio_instance`:
+
+    - risk[i, li, j, lj, t]   = round(lambda * tau[li] * tau[lj]
+                                      * cov[i, j, t] * p[i, t] * p[j, t])
+    - ret[i, l, t]            = round(tau[l] * (p[i, t+1] - p[i, t]))
+                                (zero-padded at t = T-1)
+    - tcost_pair[i, t]        = round(delta * p[i, t]) for 0 < t < T-1
+                                (transaction cost between consecutive days;
+                                zero-padded at t = 0 and t = T-1)
+    - tcost_single[i, t]      = round(delta * p[i, t]) at t = 0 and t = T-1
+                                (first-day transaction and last-day
+                                liquidation cost; zero elsewhere)
+    - short_cost[i, t]        = round(rho * p[i, t])
+    - cash_interest[k]        = round(nu * unit * 2^k)
+    - tau                     = [1, -1] (long/short indicator)
+    - pow2_y, pow2_s          = powers of two of the binary slack expansions
+    - C, B                    = capital limit, asset limit
+
+    Decision variables:
+    - x[i, m, l, t]: hold the m-th unit of asset i with position tau[l]
+                     (l = 0: long, l = 1: short) on day t
+    - y[k, t]:       binary expansion slack of the capital limit constraint
+    - s[c, t]:       binary expansion slack of the asset limit constraint
+    """
+    # Placeholders for data from file
+    A = problem.Length("A", description="Number of assets")
+    T = problem.Length("T", description="Number of allocation days")
+    risk = problem.Float("risk", ndim=5, description="Rounded risk coefficients")
+    ret = problem.Float("ret", ndim=3, description="Rounded return coefficients")
+    tcost_pair = problem.Float(
+        "tcost_pair", ndim=2, description="Rounded transaction costs (rebalancing)"
+    )
+    tcost_single = problem.Float(
+        "tcost_single", ndim=2, description="Rounded transaction costs (first/last day)"
+    )
+    short_cost = problem.Float(
+        "short_cost", ndim=2, description="Rounded short selling costs"
+    )
+    cash_interest = problem.Float(
+        "cash_interest", ndim=1, description="Rounded cash interests"
+    )
+    tau = problem.Float("tau", ndim=1, description="Position sign (1: long, -1: short)")
+    pow2_y = problem.Float("pow2_y", ndim=1, description="Powers of two for y slack")
+    pow2_s = problem.Float("pow2_s", ndim=1, description="Powers of two for s slack")
+    C = problem.Float("C", description="Capital limit in units")
+    B = problem.Float("B", description="Maximum number of assets")
+
+    # Decision variables
+    x = problem.BinaryVar(
+        "x", shape=(A, NUM_UNITS, NUM_SIGNS, T), description="Variable x"
+    )
+    y = problem.BinaryVar("y", shape=(NUM_Y_SLACKS, T), description="Slack variable y")
+    s = problem.BinaryVar("s", shape=(NUM_S_SLACKS, T), description="Slack variable s")
+
+    # Risk term
+    objective = jm.sum(
+        risk[i, li, j, lj, t] * x[i, m, li, t] * x[j, n, lj, t]
+        for t in T
+        for i in A
+        for m in jm.range(NUM_UNITS)
+        for li in jm.range(NUM_SIGNS)
+        for j in A
+        for n in jm.range(NUM_UNITS)
+        for lj in jm.range(NUM_SIGNS)
+    )
+    # Cash interest term
+    objective -= jm.sum(
+        cash_interest[k] * y[k, t] for t in T for k in jm.range(NUM_Y_SLACKS)
+    )
+    # Short selling cost term (l = 1 corresponds to tau = -1)
+    objective += jm.sum(
+        short_cost[i, t] * x[i, m, 1, t]
+        for t in T
+        for i in A
+        for m in jm.range(NUM_UNITS)
+    )
+    # Return term (zero-padded at the last day)
+    objective -= jm.sum(
+        ret[i, l, t] * x[i, m, l, t]
+        for t in T
+        for i in A
+        for m in jm.range(NUM_UNITS)
+        for l in jm.range(NUM_SIGNS)
+    )
+    # Transaction costs for rebalancing between consecutive days
+    # (tcost_pair is zero-padded at t = 0, so the t = 0 term vanishes)
+    objective += jm.sum(
+        tcost_pair[i, t]
+        * (x[i, m, l, t - 1] + x[i, m, l, t] - 2 * x[i, m, l, t - 1] * x[i, m, l, t])
+        for t in jm.range(1, T)
+        for i in A
+        for m in jm.range(NUM_UNITS)
+        for l in jm.range(NUM_SIGNS)
+    )
+    # First-day transaction and last-day liquidation costs
+    objective += jm.sum(
+        tcost_single[i, t] * x[i, m, l, t]
+        for t in T
+        for i in A
+        for m in jm.range(NUM_UNITS)
+        for l in jm.range(NUM_SIGNS)
+    )
+
+    problem += objective
+
+    # Capital limit: total position units plus slack must match C on every day
+    problem += problem.Constraint(
+        "capital_limit",
+        (
+            jm.sum(
+                tau[l] * x[i, m, l, t]
+                for i in A
+                for m in jm.range(NUM_UNITS)
+                for l in jm.range(NUM_SIGNS)
+            )
+            + jm.sum(pow2_y[k] * y[k, t] for k in jm.range(NUM_Y_SLACKS))
+            == C
+            for t in T
+        ),
+    )
+    # Number-of-assets limit: total holdings plus slack must match B on every day
+    problem += problem.Constraint(
+        "asset_limit",
+        (
+            jm.sum(
+                x[i, m, l, t]
+                for i in A
+                for m in jm.range(NUM_UNITS)
+                for l in jm.range(NUM_SIGNS)
+            )
+            + jm.sum(pow2_s[c] * s[c, t] for c in jm.range(NUM_S_SLACKS))
+            == B
+            for t in T
+        ),
+    )
+
+
+def create_problem() -> jm.Problem:
+    """
+    Create the JijModeling problem definition.
+    """
+    return _portfolio_bqp

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -37,6 +37,12 @@ LAMBDA_VALUES = [
 _INSTANCE_DIR_RE = re.compile(r"^po_a(0\d{2})_t(\d{2})_(s\d{2}|orig)$")
 
 
+def _print_name_summary(label: str, names: list[str]) -> None:
+    print(f"{label}: {len(names)} files")
+    for name in names:
+        print(f"  - {name}")
+
+
 def read_solution_lines(sol_directory: str, subdir: str, sol_name: str):
     """Read the lines of a solution file from solutions/bqp.
 
@@ -109,15 +115,18 @@ def batch_process_files(
     print("-" * 50)
 
     processed_count = 0
-    saved_without_solution_count = 0
-    mismatch_count = 0
-    error_count = 0
+    unsupported_instance_dirs: list[str] = []
+    missing_solution_names: list[str] = []
+    saved_without_solution_names: list[str] = []
+    mismatch_names: list[str] = []
+    error_names: list[str] = []
 
     for instance_dir in instance_dirs:
         dir_name = os.path.basename(instance_dir)
         match = _INSTANCE_DIR_RE.match(dir_name)
         if match is None:
             print(f"Skipping {dir_name}: no BQP model for this instance upstream.")
+            unsupported_instance_dirs.append(dir_name)
             continue
         num_assets = int(match.group(1))
         num_periods = int(match.group(2))
@@ -127,6 +136,7 @@ def batch_process_files(
                 f"Skipping {dir_name}: unsupported number of assets "
                 f"({num_assets}); known values are {sorted(B_BY_ASSETS)}."
             )
+            unsupported_instance_dirs.append(dir_name)
             continue
         b_total = B_BY_ASSETS[num_assets]
         subdir = f"a{num_assets:03d}_t{num_periods:02d}_{seed}_b{b_total:03d}"
@@ -142,6 +152,7 @@ def batch_process_files(
                         f"Warning: Solution file {sol_name} not found in "
                         f"{os.path.join(sol_directory, 'bqp')}. Skipping {base_name}."
                     )
+                    missing_solution_names.append(base_name)
                     continue
 
                 print(f"Processing {base_name}")
@@ -210,7 +221,7 @@ def batch_process_files(
                             f"Δ={diff:.6g}, feasible={solution.feasible}"
                         )
                         print(f"    Not writing {base_name}.ommx.")
-                        mismatch_count += 1
+                        mismatch_names.append(base_name)
                         continue
 
                 # Add annotations to the instance.
@@ -249,22 +260,26 @@ def batch_process_files(
                 print(f"Successfully created: {output_filename}")
                 print("-" * 50)
                 if solution is None:
-                    saved_without_solution_count += 1
+                    saved_without_solution_names.append(base_name)
                 processed_count += 1
 
             except Exception as e:
                 print(f"Error processing {base_name}: {str(e)}")
-                error_count += 1
+                error_names.append(base_name)
                 continue
 
-    print(f"\nBatch processing complete!")
+    print("\nBatch processing complete!")
     print(f"Successfully processed: {processed_count} files")
-    print(f"Saved without a solution: {saved_without_solution_count} files")
-    print(f"Verification mismatches (not written): {mismatch_count} files")
-    print(f"Number of errors: {error_count} files")
+    _print_name_summary(
+        "Unsupported instance directories skipped", unsupported_instance_dirs
+    )
+    _print_name_summary("Missing solution files skipped", missing_solution_names)
+    _print_name_summary("Saved without a solution", saved_without_solution_names)
+    _print_name_summary("Verification mismatches (not written)", mismatch_names)
+    _print_name_summary("Errors", error_names)
     print(f"OMMX files saved in: {output_directory}")
     print("-" * 50)
-    return mismatch_count + error_count
+    return len(mismatch_names) + len(error_names)
 
 
 if __name__ == "__main__":

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -77,9 +77,10 @@ def batch_process_files(
     LP files, e.g. `bqp_a010_t10_orig_b004_l0.001`.
 
     An artifact is only written when the attached solution evaluates to the
-    objective declared in the solution file and satisfies all constraints (or
-    when no solution could be evaluated, in which case the instance is saved
-    alone and reported in the summary).
+    objective declared in the solution file and satisfies all constraints.
+    Instances whose solution file is missing are skipped entirely (with a
+    warning); instances whose solution file exists but cannot be parsed or
+    evaluated are saved without a solution and reported in the summary.
 
     Parameters:
     - dat_directory: Path to the directory containing the instance directories

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -3,6 +3,7 @@ import io
 import math
 import os
 import re
+import sys
 import tarfile
 from fractions import Fraction
 
@@ -66,7 +67,7 @@ def batch_process_files(
     dat_directory: str = "../../instances",
     sol_directory: str = "../../solutions",
     output_directory: str = "./ommx_output",
-):
+) -> int:
     """
     Batch process QOBLIB portfolio instance directories and the corresponding
     solution files, and convert them into .ommx files.
@@ -75,10 +76,19 @@ def batch_process_files(
     lambda value of LAMBDA_VALUES, producing instances named like the original
     LP files, e.g. `bqp_a010_t10_orig_b004_l0.001`.
 
+    An artifact is only written when the attached solution evaluates to the
+    objective declared in the solution file and satisfies all constraints (or
+    when no solution could be evaluated, in which case the instance is saved
+    alone and reported in the summary).
+
     Parameters:
     - dat_directory: Path to the directory containing the instance directories
     - sol_directory: Path to the directory containing the solutions (bqp/...)
     - output_directory: Path to the directory where .ommx files will be saved
+
+    Returns:
+    - the number of failed conversions (verification mismatches plus errors);
+      0 means every found instance was converted.
     """
 
     # Create output directory (if it does not exist)
@@ -90,7 +100,7 @@ def batch_process_files(
     instance_dirs = sorted(glob.glob(os.path.join(dat_directory, "po_*")))
     if not instance_dirs:
         print(f"No po_* instance directories found in {dat_directory}")
-        return
+        return 1
 
     print(f"Found {len(instance_dirs)} instance directories in {dat_directory}")
     print(f"Solution files directory: {sol_directory}")
@@ -98,6 +108,8 @@ def batch_process_files(
     print("-" * 50)
 
     processed_count = 0
+    saved_without_solution_count = 0
+    mismatch_count = 0
     error_count = 0
 
     for instance_dir in instance_dirs:
@@ -162,7 +174,17 @@ def batch_process_files(
                         for (name, subscripts), value in sol_values.items()
                     }
                     solution = ommx_instance.evaluate(state)
+                except Exception as sol_error:
+                    print(f"  ! Error evaluating solution: {sol_error}")
+                    print(
+                        "    Skipping solution evaluation and only saving the instance..."
+                    )
+                    solution = None
 
+                # Verify the evaluated solution; an artifact with a solution
+                # that does not reproduce the declared objective (or violates
+                # a constraint) must never be written, or it could be uploaded.
+                if solution is not None:
                     if (
                         math.isclose(
                             sol_objective,
@@ -186,19 +208,9 @@ def batch_process_files(
                             f"  ✗ mismatch: calc={solution.objective:.6f}, sol={sol_objective:.6f}, "
                             f"Δ={diff:.6g}, feasible={solution.feasible}"
                         )
-
-                except Exception as sol_error:
-                    print(f"  ! Error evaluating solution: {sol_error}")
-                    print(
-                        "    Skipping solution evaluation and only saving the instance..."
-                    )
-
-                # Construct the output filename
-                output_filename = os.path.join(output_directory, f"{base_name}.ommx")
-
-                # If the file already exists, remove it
-                if os.path.exists(output_filename):
-                    os.remove(output_filename)
+                        print(f"    Not writing {base_name}.ommx.")
+                        mismatch_count += 1
+                        continue
 
                 # Add annotations to the instance.
                 ommx_instance.title = base_name
@@ -211,19 +223,32 @@ def batch_process_files(
                     "https://git.zib.de/qopt/qoblib-quantum-optimization-benchmarking-library/-/tree/main/06-portfolio?ref_type=heads"
                 )
 
-                # Create OMMX Artifact
-                builder = ArtifactBuilder.new_archive_unnamed(output_filename)
-                instance_desc = builder.add_instance(ommx_instance)
-                if solution is not None:
-                    solution.instance = instance_desc.digest
-                    solution.annotations["org.ommx.qoblib.authors"] = (
-                        QOBLIB_AUTHORS_STR
-                    )
-                    builder.add_solution(solution)
-                builder.build()
+                # Create the OMMX Artifact in a temporary file and atomically
+                # replace the final .ommx, so that a failure can never leave a
+                # partial artifact behind (the uploader picks up *.ommx).
+                output_filename = os.path.join(output_directory, f"{base_name}.ommx")
+                tmp_filename = f"{output_filename}.tmp"
+                if os.path.exists(tmp_filename):
+                    os.remove(tmp_filename)
+                try:
+                    builder = ArtifactBuilder.new_archive_unnamed(tmp_filename)
+                    instance_desc = builder.add_instance(ommx_instance)
+                    if solution is not None:
+                        solution.instance = instance_desc.digest
+                        solution.annotations["org.ommx.qoblib.authors"] = (
+                            QOBLIB_AUTHORS_STR
+                        )
+                        builder.add_solution(solution)
+                    builder.build()
+                    os.replace(tmp_filename, output_filename)
+                finally:
+                    if os.path.exists(tmp_filename):
+                        os.remove(tmp_filename)
 
                 print(f"Successfully created: {output_filename}")
                 print("-" * 50)
+                if solution is None:
+                    saved_without_solution_count += 1
                 processed_count += 1
 
             except Exception as e:
@@ -233,10 +258,13 @@ def batch_process_files(
 
     print(f"\nBatch processing complete!")
     print(f"Successfully processed: {processed_count} files")
+    print(f"Saved without a solution: {saved_without_solution_count} files")
+    print(f"Verification mismatches (not written): {mismatch_count} files")
     print(f"Number of errors: {error_count} files")
     print(f"OMMX files saved in: {output_directory}")
     print("-" * 50)
+    return mismatch_count + error_count
 
 
 if __name__ == "__main__":
-    batch_process_files()
+    sys.exit(1 if batch_process_files() else 0)

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -9,7 +9,12 @@ from fractions import Fraction
 
 from ommx.artifact import ArtifactBuilder
 from sol_reader import parse_sol_file
-from dat_reader import B_BY_ASSETS, read_portfolio_instance
+from dat_reader import (
+    B_BY_ASSETS,
+    compute_coefficients,
+    read_covariance_matrix,
+    read_stock_prices,
+)
 from model import create_problem
 from ommx_quantum_benchmarks.qoblib.definitions import (
     QOBLIB_AUTHORS,
@@ -141,6 +146,22 @@ def batch_process_files(
         b_total = B_BY_ASSETS[num_assets]
         subdir = f"a{num_assets:03d}_t{num_periods:02d}_{seed}_b{b_total:03d}"
 
+        # Read the instance files once per directory; only the lambda-dependent
+        # coefficients are recomputed inside the lambda loop below.
+        try:
+            symbols, prices = read_stock_prices(instance_dir, num_assets)
+            num_days = len(prices[0])
+            if num_days != num_periods:
+                raise ValueError(
+                    f"Number of days read from {dir_name} is {num_days}, "
+                    f"but the directory name implies {num_periods}."
+                )
+            cov = read_covariance_matrix(instance_dir, symbols, num_periods)
+        except Exception as e:
+            print(f"Error reading instance directory {dir_name}: {str(e)}")
+            error_names.append(dir_name)
+            continue
+
         for lam_suffix, sol_suffix in LAMBDA_VALUES:
             lam = Fraction(lam_suffix)
             base_name = f"bqp_{subdir}_l{lam_suffix}"
@@ -157,16 +178,8 @@ def batch_process_files(
 
                 print(f"Processing {base_name}")
 
-                # Read the instance data
-                instance_data, symbols = read_portfolio_instance(
-                    instance_dir, lam, num_assets
-                )
-                if instance_data["T"] != num_periods:
-                    raise ValueError(
-                        f"Number of days read from {dir_name} is "
-                        f"{instance_data['T']}, but the directory name implies "
-                        f"{num_periods}."
-                    )
+                # Build the lambda-dependent coefficient arrays
+                instance_data = compute_coefficients(lam, prices, cov, num_assets)
 
                 # Create an OMMX instance
                 ommx_instance = problem.eval(instance_data)

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -109,6 +109,12 @@ def batch_process_files(
         num_assets = int(match.group(1))
         num_periods = int(match.group(2))
         seed = match.group(3)
+        if num_assets not in B_BY_ASSETS:
+            print(
+                f"Skipping {dir_name}: unsupported number of assets "
+                f"({num_assets}); known values are {sorted(B_BY_ASSETS)}."
+            )
+            continue
         b_total = B_BY_ASSETS[num_assets]
         subdir = f"a{num_assets:03d}_t{num_periods:02d}_{seed}_b{b_total:03d}"
 
@@ -131,6 +137,12 @@ def batch_process_files(
                 instance_data, symbols = read_portfolio_instance(
                     instance_dir, lam, num_assets
                 )
+                if instance_data["T"] != num_periods:
+                    raise ValueError(
+                        f"Number of days read from {dir_name} is "
+                        f"{instance_data['T']}, but the directory name implies "
+                        f"{num_periods}."
+                    )
 
                 # Create an OMMX instance
                 ommx_instance = problem.eval(instance_data)
@@ -153,7 +165,10 @@ def batch_process_files(
 
                     if (
                         math.isclose(
-                            sol_objective, solution.objective, rel_tol=1e-6
+                            sol_objective,
+                            solution.objective,
+                            rel_tol=1e-6,
+                            abs_tol=1e-6,
                         )
                         and solution.feasible
                     ):

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -56,7 +56,8 @@ def read_solution_lines(sol_directory: str, subdir: str, sol_name: str):
                 return None
             if member is None:
                 return None
-            return io.TextIOWrapper(member, encoding="utf-8").readlines()
+            with io.TextIOWrapper(member, encoding="utf-8") as text:
+                return text.readlines()
 
     return None
 

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/ommx_create.py
@@ -1,0 +1,226 @@
+import glob
+import io
+import math
+import os
+import re
+import tarfile
+from fractions import Fraction
+
+from ommx.artifact import ArtifactBuilder
+from sol_reader import parse_sol_file
+from dat_reader import B_BY_ASSETS, read_portfolio_instance
+from model import create_problem
+from ommx_quantum_benchmarks.qoblib.definitions import (
+    QOBLIB_AUTHORS,
+    QOBLIB_AUTHORS_STR,
+    LICENSE,
+)
+
+# Lambda (risk weight) values used by gen_archive.sh of the original QOBLIB
+# repository, as (instance-name suffix, solution-file suffix).  The instance
+# name suffix doubles as the exact decimal value of lambda.
+LAMBDA_VALUES = [
+    ("0", "0.0"),
+    ("0.000001", "1e-06"),
+    ("0.00001", "1e-05"),
+    ("0.00005", "5e-05"),
+    ("0.0001", "0.0001"),
+    ("0.0005", "0.0005"),
+    ("0.001", "0.001"),
+    ("0.01", "0.01"),
+]
+
+# Same directory pattern as gen_archive.sh ("po_a0*"): the original QOBLIB
+# repository provides BQP models and solutions only for the 10- and 50-asset
+# instances.
+_INSTANCE_DIR_RE = re.compile(r"^po_a(0\d{2})_t(\d{2})_(s\d{2}|orig)$")
+
+
+def read_solution_lines(sol_directory: str, subdir: str, sol_name: str):
+    """Read the lines of a solution file from solutions/bqp.
+
+    Supports both an extracted directory (`bqp/<subdir>/<sol_name>`) and the
+    distributed archive (`bqp/<subdir>.tar.gz`).  Returns None if not found.
+    """
+    sol_path = os.path.join(sol_directory, "bqp", subdir, sol_name)
+    if os.path.exists(sol_path):
+        with open(sol_path, "r", encoding="utf-8") as f:
+            return f.readlines()
+
+    tar_path = os.path.join(sol_directory, "bqp", f"{subdir}.tar.gz")
+    if os.path.exists(tar_path):
+        with tarfile.open(tar_path, "r:gz") as tar:
+            try:
+                member = tar.extractfile(f"{subdir}/{sol_name}")
+            except KeyError:
+                return None
+            if member is None:
+                return None
+            return io.TextIOWrapper(member, encoding="utf-8").readlines()
+
+    return None
+
+
+def batch_process_files(
+    dat_directory: str = "../../instances",
+    sol_directory: str = "../../solutions",
+    output_directory: str = "./ommx_output",
+):
+    """
+    Batch process QOBLIB portfolio instance directories and the corresponding
+    solution files, and convert them into .ommx files.
+
+    Each instance directory `po_aXXX_tXX_{sXX|orig}` is combined with every
+    lambda value of LAMBDA_VALUES, producing instances named like the original
+    LP files, e.g. `bqp_a010_t10_orig_b004_l0.001`.
+
+    Parameters:
+    - dat_directory: Path to the directory containing the instance directories
+    - sol_directory: Path to the directory containing the solutions (bqp/...)
+    - output_directory: Path to the directory where .ommx files will be saved
+    """
+
+    # Create output directory (if it does not exist)
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Create the problem definition (shared by all instances)
+    problem = create_problem()
+
+    instance_dirs = sorted(glob.glob(os.path.join(dat_directory, "po_*")))
+    if not instance_dirs:
+        print(f"No po_* instance directories found in {dat_directory}")
+        return
+
+    print(f"Found {len(instance_dirs)} instance directories in {dat_directory}")
+    print(f"Solution files directory: {sol_directory}")
+    print(f"Output directory: {output_directory}")
+    print("-" * 50)
+
+    processed_count = 0
+    error_count = 0
+
+    for instance_dir in instance_dirs:
+        dir_name = os.path.basename(instance_dir)
+        match = _INSTANCE_DIR_RE.match(dir_name)
+        if match is None:
+            print(f"Skipping {dir_name}: no BQP model for this instance upstream.")
+            continue
+        num_assets = int(match.group(1))
+        num_periods = int(match.group(2))
+        seed = match.group(3)
+        b_total = B_BY_ASSETS[num_assets]
+        subdir = f"a{num_assets:03d}_t{num_periods:02d}_{seed}_b{b_total:03d}"
+
+        for lam_suffix, sol_suffix in LAMBDA_VALUES:
+            lam = Fraction(lam_suffix)
+            base_name = f"bqp_{subdir}_l{lam_suffix}"
+            try:
+                sol_name = f"{subdir}_l{sol_suffix}.sol"
+                sol_lines = read_solution_lines(sol_directory, subdir, sol_name)
+                if sol_lines is None:
+                    print(
+                        f"Warning: Solution file {sol_name} not found in "
+                        f"{os.path.join(sol_directory, 'bqp')}. Skipping {base_name}."
+                    )
+                    continue
+
+                print(f"Processing {base_name}")
+
+                # Read the instance data
+                instance_data, symbols = read_portfolio_instance(
+                    instance_dir, lam, num_assets
+                )
+
+                # Create an OMMX instance
+                ommx_instance = problem.eval(instance_data)
+
+                # Read and evaluate the solution
+                solution = None
+                try:
+                    sol_objective, sol_values = parse_sol_file(
+                        sol_lines, symbols, num_periods
+                    )
+                    var_ids = {
+                        (var.name, tuple(var.subscripts)): var.id
+                        for var in ommx_instance.decision_variables
+                    }
+                    state = {
+                        var_ids[(name, subscripts)]: value
+                        for (name, subscripts), value in sol_values.items()
+                    }
+                    solution = ommx_instance.evaluate(state)
+
+                    if (
+                        math.isclose(
+                            sol_objective, solution.objective, rel_tol=1e-6
+                        )
+                        and solution.feasible
+                    ):
+                        print(
+                            f"  → Calculated objective={solution.objective:.6f}, "
+                            f"Solution objective={sol_objective:.6f}"
+                        )
+                        print(
+                            f"  → objective={solution.objective:.6f}, feasible={solution.feasible}"
+                        )
+                    else:
+                        diff = solution.objective - sol_objective
+                        print("Objective or feasible Error")
+                        print(
+                            f"  ✗ mismatch: calc={solution.objective:.6f}, sol={sol_objective:.6f}, "
+                            f"Δ={diff:.6g}, feasible={solution.feasible}"
+                        )
+
+                except Exception as sol_error:
+                    print(f"  ! Error evaluating solution: {sol_error}")
+                    print(
+                        "    Skipping solution evaluation and only saving the instance..."
+                    )
+
+                # Construct the output filename
+                output_filename = os.path.join(output_directory, f"{base_name}.ommx")
+
+                # If the file already exists, remove it
+                if os.path.exists(output_filename):
+                    os.remove(output_filename)
+
+                # Add annotations to the instance.
+                ommx_instance.title = base_name
+                ommx_instance.license = LICENSE
+                ommx_instance.dataset = "Portfolio Optimization"
+                ommx_instance.authors = QOBLIB_AUTHORS
+                ommx_instance.num_variables = len(ommx_instance.decision_variables)
+                ommx_instance.num_constraints = len(ommx_instance.constraints)
+                ommx_instance.annotations["org.ommx.qoblib.url"] = (
+                    "https://git.zib.de/qopt/qoblib-quantum-optimization-benchmarking-library/-/tree/main/06-portfolio?ref_type=heads"
+                )
+
+                # Create OMMX Artifact
+                builder = ArtifactBuilder.new_archive_unnamed(output_filename)
+                instance_desc = builder.add_instance(ommx_instance)
+                if solution is not None:
+                    solution.instance = instance_desc.digest
+                    solution.annotations["org.ommx.qoblib.authors"] = (
+                        QOBLIB_AUTHORS_STR
+                    )
+                    builder.add_solution(solution)
+                builder.build()
+
+                print(f"Successfully created: {output_filename}")
+                print("-" * 50)
+                processed_count += 1
+
+            except Exception as e:
+                print(f"Error processing {base_name}: {str(e)}")
+                error_count += 1
+                continue
+
+    print(f"\nBatch processing complete!")
+    print(f"Successfully processed: {processed_count} files")
+    print(f"Number of errors: {error_count} files")
+    print(f"OMMX files saved in: {output_directory}")
+    print("-" * 50)
+
+
+if __name__ == "__main__":
+    batch_process_files()

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -9,7 +9,9 @@ NUM_SIGNS = 2
 NUM_Y_SLACKS = 4
 NUM_S_SLACKS = 7
 
-_OBJECTIVE_RE = re.compile(r"#\s*Objective value\s*=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)")
+_OBJECTIVE_RE = re.compile(
+    r"#\s*Objective value\s*=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)", re.IGNORECASE
+)
 
 
 def parse_sol_file(
@@ -76,6 +78,12 @@ def parse_sol_file(
             if "@" in name:
                 # Mangled (truncated) name: decode via the declaration index.
                 decl_index = int(name.rsplit("@", 1)[1], 16)
+                if decl_index >= len(x_decl):
+                    raise ValueError(
+                        f"Declaration index {decl_index} from {name!r} is out of "
+                        f"range for {len(x_decl)} x variables; the symbol list or "
+                        f"num_periods ({num_periods}) is likely wrong."
+                    )
                 subscripts = x_decl[decl_index]
             else:
                 _, symbol, m, tau, t = name.replace("$", "#").split("#")

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -14,6 +14,22 @@ _OBJECTIVE_RE = re.compile(
 )
 
 
+def _slack_subscripts(name: str, width: int, num_periods: int) -> tuple[int, int]:
+    """Parse a slack variable name `y#<k>#<t>` / `s2#<c>#<t>` into subscripts."""
+    parts = name.split("#")
+    try:
+        if len(parts) != 3:
+            raise ValueError
+        k, t = int(parts[1]), int(parts[2])
+    except ValueError:
+        raise ValueError(
+            f"Unrecognized slack variable name in solution file: {name!r}"
+        ) from None
+    if not 0 <= k < width or not 0 <= t < num_periods:
+        raise ValueError(f"Subscripts out of range in solution file variable {name!r}.")
+    return (k, t)
+
+
 def parse_sol_file(
     lines, symbols: list[str], num_periods: int
 ) -> tuple[float, dict[tuple[str, tuple[int, ...]], float]]:
@@ -33,14 +49,16 @@ def parse_sol_file(
       (`var x[SX*TX]` with SX = S * {1..ub} * {1,-1}, day fastest), which we
       use to recover the subscripts.
 
+    Variables omitted by the solver are filled with 0, since Gurobi .sol
+    writers commonly drop zero-valued variables; the returned dict therefore
+    always covers the full model.  Malformed lines, non-binary values, unknown
+    symbols, out-of-range subscripts, and duplicate variables raise ValueError
+    so that a corrupt solution file can never be mapped silently.
+
     Args:
         lines: iterable of text lines of the solution file.
         symbols: stock symbols in price-file order (defines the asset index).
         num_periods: number of allocation days T.
-
-    Variables omitted by the solver are filled with 0, since Gurobi .sol
-    writers commonly drop zero-valued variables; the returned dict therefore
-    always covers the full model.
 
     Returns:
         A tuple of:
@@ -70,14 +88,36 @@ def parse_sol_file(
                 objective = float(match.group(1))
             continue
 
-        name, value_str = line.rsplit(None, 1)
+        parts = line.rsplit(None, 1)
+        if len(parts) != 2:
+            raise ValueError(f"Malformed line in solution file: {line!r}")
+        name, value_str = parts
         name = name.strip()
-        value = float(value_str)
+        try:
+            value = float(value_str)
+        except ValueError:
+            raise ValueError(
+                f"Malformed value in solution file line: {line!r}"
+            ) from None
+        # All model variables are binary; tolerate solver output like
+        # 0.9999999996 but reject anything that is not a 0/1 within tolerance.
+        rounded = round(value)
+        if abs(value - rounded) > 1e-6 or rounded not in (0, 1):
+            raise ValueError(
+                f"Non-binary value {value} for variable {name!r} in solution file."
+            )
+        value = float(rounded)
 
         if name.startswith("x$"):
             if "@" in name:
                 # Mangled (truncated) name: decode via the declaration index.
-                decl_index = int(name.rsplit("@", 1)[1], 16)
+                try:
+                    decl_index = int(name.rsplit("@", 1)[1], 16)
+                except ValueError:
+                    raise ValueError(
+                        f"Unrecognized mangled variable name in solution file: "
+                        f"{name!r}"
+                    ) from None
                 if decl_index >= len(x_decl):
                     raise ValueError(
                         f"Declaration index {decl_index} from {name!r} is out of "
@@ -86,20 +126,43 @@ def parse_sol_file(
                     )
                 subscripts = x_decl[decl_index]
             else:
-                _, symbol, m, tau, t = name.replace("$", "#").split("#")
-                # ZIMPL replaces the invalid character '-' with '_', so a short
-                # (non-truncated) tau = -1 name carries "_1" rather than "-1".
-                l = 0 if int(tau.replace("_", "-")) == 1 else 1
-                subscripts = (sym_idx[symbol], int(m) - 1, l, int(t))
-            values[("x", subscripts)] = value
+                name_parts = name.replace("$", "#").split("#")
+                if len(name_parts) != 5:
+                    raise ValueError(
+                        f"Unrecognized x variable name in solution file: {name!r}"
+                    )
+                _, symbol, m_str, tau_str, t_str = name_parts
+                if symbol not in sym_idx:
+                    raise ValueError(
+                        f"Unknown symbol {symbol!r} in solution file variable "
+                        f"{name!r}."
+                    )
+                try:
+                    m = int(m_str)
+                    # ZIMPL replaces the invalid character '-' with '_', so a
+                    # short (non-truncated) tau = -1 name carries "_1".
+                    tau = int(tau_str.replace("_", "-"))
+                    t = int(t_str)
+                except ValueError:
+                    raise ValueError(
+                        f"Unrecognized x variable name in solution file: {name!r}"
+                    ) from None
+                if tau not in (1, -1) or not 1 <= m <= UB or not 0 <= t < num_periods:
+                    raise ValueError(
+                        f"Subscripts out of range in solution file variable {name!r}."
+                    )
+                subscripts = (sym_idx[symbol], m - 1, 0 if tau == 1 else 1, t)
+            key = ("x", subscripts)
         elif name.startswith("y#"):
-            _, k, t = name.split("#")
-            values[("y", (int(k), int(t)))] = value
+            key = ("y", _slack_subscripts(name, NUM_Y_SLACKS, num_periods))
         elif name.startswith("s2#"):
-            _, c, t = name.split("#")
-            values[("s", (int(c), int(t)))] = value
+            key = ("s", _slack_subscripts(name, NUM_S_SLACKS, num_periods))
         else:
             raise ValueError(f"Unrecognized variable name in solution file: {name}")
+
+        if key in values:
+            raise ValueError(f"Duplicate variable {name!r} in solution file.")
+        values[key] = value
 
     if objective is None:
         raise ValueError("No '# Objective value = ...' header found.")

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -23,9 +23,10 @@ def parse_sol_file(
     output:
 
     - `y#<k>#<t>` and `s2#<c>#<t>` for the slack variables,
-    - `x$<symbol>#<m>#<tau>#<t>` for the asset variables with tau = 1,
-    - mangled names like `x$AAPL#1#_1#0@a` for tau = -1.  ZIMPL replaces the
-      invalid character '-' and truncates long names, appending '@' and the
+    - `x$<symbol>#<m>#<tau>#<t>` for the asset variables, where ZIMPL replaces
+      the invalid character '-' with '_', so tau = -1 appears as `_1`,
+    - mangled names like `x$AAPL#1#_1#0@a` for long (truncated) names.  ZIMPL
+      truncates such names, appending '@' and the
       0-based variable index in declaration order
       (`var x[SX*TX]` with SX = S * {1..ub} * {1,-1}, day fastest), which we
       use to recover the subscripts.
@@ -78,7 +79,9 @@ def parse_sol_file(
                 subscripts = x_decl[decl_index]
             else:
                 _, symbol, m, tau, t = name.replace("$", "#").split("#")
-                l = 0 if int(tau) == 1 else 1
+                # ZIMPL replaces the invalid character '-' with '_', so a short
+                # (non-truncated) tau = -1 name carries "_1" rather than "-1".
+                l = 0 if int(tau.replace("_", "-")) == 1 else 1
                 subscripts = (sym_idx[symbol], int(m) - 1, l, int(t))
             values[("x", subscripts)] = value
         elif name.startswith("y#"):

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -1,13 +1,6 @@
 import re
 
-# Number of units per asset and position (ub in parameter_u3_c10.zpl).
-UB = 3
-# Number of position signs: tau = 1 (long, l = 0) and tau = -1 (short, l = 1).
-NUM_SIGNS = 2
-# Binary expansion widths of the two slack variables (CS1, CS2 in
-# parameter_u3_c10.zpl).
-NUM_Y_SLACKS = 4
-NUM_S_SLACKS = 7
+from constants import NUM_S_SLACKS, NUM_SIGNS, NUM_UNITS, NUM_Y_SLACKS
 
 _OBJECTIVE_RE = re.compile(
     r"#\s*Objective value\s*=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)", re.IGNORECASE
@@ -71,7 +64,7 @@ def parse_sol_file(
     x_decl = [
         (i, m, l, t)
         for i in range(len(symbols))
-        for m in range(UB)
+        for m in range(NUM_UNITS)
         for l in range(NUM_SIGNS)
         for t in range(num_periods)
     ]
@@ -147,7 +140,11 @@ def parse_sol_file(
                     raise ValueError(
                         f"Unrecognized x variable name in solution file: {name!r}"
                     ) from None
-                if tau not in (1, -1) or not 1 <= m <= UB or not 0 <= t < num_periods:
+                if (
+                    tau not in (1, -1)
+                    or not 1 <= m <= NUM_UNITS
+                    or not 0 <= t < num_periods
+                ):
                     raise ValueError(
                         f"Subscripts out of range in solution file variable {name!r}."
                     )

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -1,0 +1,92 @@
+import re
+
+# Number of units per asset and position (ub in parameter_u3_c10.zpl).
+UB = 3
+# Number of position signs: tau = 1 (long, l = 0) and tau = -1 (short, l = 1).
+NUM_SIGNS = 2
+
+_OBJECTIVE_RE = re.compile(r"#\s*Objective value\s*=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)")
+
+
+def parse_sol_file(
+    lines, symbols: list[str], num_periods: int
+) -> tuple[float, dict[tuple[str, tuple[int, ...]], float]]:
+    """Parse a QOBLIB portfolio solution file in Gurobi .sol format.
+
+    The solution files under `solutions/bqp` of the original QOBLIB repository
+    contain one variable per line (`<name> <value>`) plus an
+    `# Objective value = ...` header.  Variable names come from ZIMPL's LP
+    output:
+
+    - `y#<k>#<t>` and `s2#<c>#<t>` for the slack variables,
+    - `x$<symbol>#<m>#<tau>#<t>` for the asset variables with tau = 1,
+    - mangled names like `x$AAPL#1#_1#0@a` for tau = -1.  ZIMPL replaces the
+      invalid character '-' and truncates long names, appending '@' and the
+      0-based variable index in declaration order
+      (`var x[SX*TX]` with SX = S * {1..ub} * {1,-1}, day fastest), which we
+      use to recover the subscripts.
+
+    Args:
+        lines: iterable of text lines of the solution file.
+        symbols: stock symbols in price-file order (defines the asset index).
+        num_periods: number of allocation days T.
+
+    Returns:
+        A tuple of:
+        - the objective value declared in the file header,
+        - dict mapping (variable name, subscripts) to the variable value,
+          with subscripts (i, m, l, t) for "x" and (k, t) for "y" / "s".
+    """
+    sym_idx = {s: i for i, s in enumerate(symbols)}
+    # Declaration order of x[SX*TX]: asset, unit, sign, day (day fastest).
+    x_decl = [
+        (i, m, l, t)
+        for i in range(len(symbols))
+        for m in range(UB)
+        for l in range(NUM_SIGNS)
+        for t in range(num_periods)
+    ]
+
+    objective = None
+    values: dict[tuple[str, tuple[int, ...]], float] = {}
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            match = _OBJECTIVE_RE.match(line)
+            if match:
+                objective = float(match.group(1))
+            continue
+
+        name, value_str = line.rsplit(None, 1)
+        name = name.strip()
+        value = float(value_str)
+
+        if name.startswith("x$"):
+            if "@" in name:
+                # Mangled (truncated) name: decode via the declaration index.
+                decl_index = int(name.rsplit("@", 1)[1], 16)
+                subscripts = x_decl[decl_index]
+            else:
+                _, symbol, m, tau, t = name.replace("$", "#").split("#")
+                l = 0 if int(tau) == 1 else 1
+                subscripts = (sym_idx[symbol], int(m) - 1, l, int(t))
+            values[("x", subscripts)] = value
+        elif name.startswith("y#"):
+            _, k, t = name.split("#")
+            values[("y", (int(k), int(t)))] = value
+        elif name.startswith("s2#"):
+            _, c, t = name.split("#")
+            values[("s", (int(c), int(t)))] = value
+        else:
+            raise ValueError(f"Unrecognized variable name in solution file: {name}")
+
+    if objective is None:
+        raise ValueError("No '# Objective value = ...' header found.")
+    expected = len(x_decl) + 4 * num_periods + 7 * num_periods
+    if len(values) != expected:
+        raise ValueError(
+            f"Expected {expected} variables in solution file, but got {len(values)}."
+        )
+    return objective, values

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -4,6 +4,10 @@ import re
 UB = 3
 # Number of position signs: tau = 1 (long, l = 0) and tau = -1 (short, l = 1).
 NUM_SIGNS = 2
+# Binary expansion widths of the two slack variables (CS1, CS2 in
+# parameter_u3_c10.zpl).
+NUM_Y_SLACKS = 4
+NUM_S_SLACKS = 7
 
 _OBJECTIVE_RE = re.compile(r"#\s*Objective value\s*=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)")
 
@@ -30,6 +34,10 @@ def parse_sol_file(
         lines: iterable of text lines of the solution file.
         symbols: stock symbols in price-file order (defines the asset index).
         num_periods: number of allocation days T.
+
+    Variables omitted by the solver are filled with 0, since Gurobi .sol
+    writers commonly drop zero-valued variables; the returned dict therefore
+    always covers the full model.
 
     Returns:
         A tuple of:
@@ -84,9 +92,23 @@ def parse_sol_file(
 
     if objective is None:
         raise ValueError("No '# Objective value = ...' header found.")
-    expected = len(x_decl) + 4 * num_periods + 7 * num_periods
-    if len(values) != expected:
+
+    # Gurobi .sol writers may omit zero-valued variables, so fewer entries than
+    # the full model is valid; only more than expected (e.g. a wrong
+    # num_periods or an unexpected variable) is an error. Fill the omitted
+    # variables with 0 so the returned assignment covers the whole model.
+    expected = len(x_decl) + NUM_Y_SLACKS * num_periods + NUM_S_SLACKS * num_periods
+    if len(values) > expected:
         raise ValueError(
-            f"Expected {expected} variables in solution file, but got {len(values)}."
+            f"Expected at most {expected} variables in solution file, "
+            f"but got {len(values)}."
         )
+    for subscripts in x_decl:
+        values.setdefault(("x", subscripts), 0.0)
+    for k in range(NUM_Y_SLACKS):
+        for t in range(num_periods):
+            values.setdefault(("y", (k, t)), 0.0)
+    for c in range(NUM_S_SLACKS):
+        for t in range(num_periods):
+            values.setdefault(("s", (c, t)), 0.0)
     return objective, values

--- a/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
+++ b/ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/sol_reader.py
@@ -1,10 +1,11 @@
 import re
 
-from constants import NUM_S_SLACKS, NUM_SIGNS, NUM_UNITS, NUM_Y_SLACKS
+from constants import NUM_S_SLACKS, NUM_SIGNS, NUM_UNITS, NUM_Y_SLACKS, TAU
 
 _OBJECTIVE_RE = re.compile(
     r"#\s*Objective value\s*=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)", re.IGNORECASE
 )
+BINARY_FEASIBILITY_TOLERANCE = 1e-5
 
 
 def _slack_subscripts(name: str, width: int, num_periods: int) -> tuple[int, int]:
@@ -23,9 +24,16 @@ def _slack_subscripts(name: str, width: int, num_periods: int) -> tuple[int, int
     return (k, t)
 
 
+def _zimpl_x_name(symbols: list[str], subscripts: tuple[int, int, int, int]) -> str:
+    """Reconstruct the unmangled ZIMPL LP name for an x variable."""
+    i, m, l, t = subscripts
+    tau_name = str(TAU[l]).replace("-", "_")
+    return f"x${symbols[i]}#{m + 1}#{tau_name}#{t}"
+
+
 def parse_sol_file(
     lines, symbols: list[str], num_periods: int
-) -> tuple[float, dict[tuple[str, tuple[int, ...]], float]]:
+) -> tuple[float, dict[tuple[str, tuple[int, ...]], int]]:
     """Parse a QOBLIB portfolio solution file in Gurobi .sol format.
 
     The solution files under `solutions/bqp` of the original QOBLIB repository
@@ -36,11 +44,13 @@ def parse_sol_file(
     - `y#<k>#<t>` and `s2#<c>#<t>` for the slack variables,
     - `x$<symbol>#<m>#<tau>#<t>` for the asset variables, where ZIMPL replaces
       the invalid character '-' with '_', so tau = -1 appears as `_1`,
-    - mangled names like `x$AAPL#1#_1#0@a` for long (truncated) names.  ZIMPL
-      truncates such names, appending '@' and the
-      0-based variable index in declaration order
-      (`var x[SX*TX]` with SX = S * {1..ub} * {1,-1}, day fastest), which we
-      use to recover the subscripts.
+    - mangled names like `x$AAPL#1#_1#0@a` for long (truncated) names.  When
+      LP variable names exceed ZIMPL's output-name limit, ZIMPL keeps a prefix
+      and appends `@<hex declaration index>`.  The declaration order is
+      `var x[SX*TX]` with SX = S * {1..ub} * {1,-1}, followed by day, so it is
+      asset -> unit -> sign -> day (day fastest).  We reproduce that order in
+      `x_decl`, recover the subscripts from the hex index, then verify that the
+      full reconstructed ZIMPL name starts with the retained prefix.
 
     Variables omitted by the solver are filled with 0, since Gurobi .sol
     writers commonly drop zero-valued variables; the returned dict therefore
@@ -56,8 +66,9 @@ def parse_sol_file(
     Returns:
         A tuple of:
         - the objective value declared in the file header,
-        - dict mapping (variable name, subscripts) to the variable value,
-          with subscripts (i, m, l, t) for "x" and (k, t) for "y" / "s".
+        - dict mapping (variable name, subscripts) to the integer variable
+          value, with subscripts (i, m, l, t) for "x" and (k, t) for
+          "y" / "s2".
     """
     sym_idx = {s: i for i, s in enumerate(symbols)}
     # Declaration order of x[SX*TX]: asset, unit, sign, day (day fastest).
@@ -70,7 +81,7 @@ def parse_sol_file(
     ]
 
     objective = None
-    values: dict[tuple[str, tuple[int, ...]], float] = {}
+    values: dict[tuple[str, tuple[int, ...]], int] = {}
     for raw in lines:
         line = raw.strip()
         if not line:
@@ -92,18 +103,25 @@ def parse_sol_file(
             raise ValueError(
                 f"Malformed value in solution file line: {line!r}"
             ) from None
-        # All model variables are binary; tolerate solver output like
-        # 0.9999999996 but reject anything that is not a 0/1 within tolerance.
+        # All model variables are binary. Use Gurobi's default IntFeasTol so
+        # valid .sol output is not rejected before ommx_create.py performs the
+        # objective and feasibility checks that gate artifact writing.
         rounded = round(value)
-        if abs(value - rounded) > 1e-6 or rounded not in (0, 1):
+        if (
+            abs(value - rounded) > BINARY_FEASIBILITY_TOLERANCE
+            or rounded not in (0, 1)
+        ):
             raise ValueError(
                 f"Non-binary value {value} for variable {name!r} in solution file."
             )
-        value = float(rounded)
+        value = int(rounded)
 
         if name.startswith("x$"):
             if "@" in name:
                 # Mangled (truncated) name: decode via the declaration index.
+                # The retained prefix is checked below against the reconstructed
+                # full name, so a stale symbol list or wrong declaration-order
+                # assumption is caught instead of silently remapping variables.
                 try:
                     decl_index = int(name.rsplit("@", 1)[1], 16)
                 except ValueError:
@@ -111,13 +129,20 @@ def parse_sol_file(
                         f"Unrecognized mangled variable name in solution file: "
                         f"{name!r}"
                     ) from None
-                if decl_index >= len(x_decl):
+                if not 0 <= decl_index < len(x_decl):
                     raise ValueError(
                         f"Declaration index {decl_index} from {name!r} is out of "
                         f"range for {len(x_decl)} x variables; the symbol list or "
                         f"num_periods ({num_periods}) is likely wrong."
                     )
                 subscripts = x_decl[decl_index]
+                prefix = name.rsplit("@", 1)[0]
+                full_name = _zimpl_x_name(symbols, subscripts)
+                if not full_name.startswith(prefix):
+                    raise ValueError(
+                        f"Mangled variable name {name!r} decodes to {full_name!r}, "
+                        f"which does not match the retained prefix {prefix!r}."
+                    )
             else:
                 name_parts = name.replace("$", "#").split("#")
                 if len(name_parts) != 5:
@@ -141,19 +166,19 @@ def parse_sol_file(
                         f"Unrecognized x variable name in solution file: {name!r}"
                     ) from None
                 if (
-                    tau not in (1, -1)
+                    tau not in TAU
                     or not 1 <= m <= NUM_UNITS
                     or not 0 <= t < num_periods
                 ):
                     raise ValueError(
                         f"Subscripts out of range in solution file variable {name!r}."
                     )
-                subscripts = (sym_idx[symbol], m - 1, 0 if tau == 1 else 1, t)
+                subscripts = (sym_idx[symbol], m - 1, TAU.index(tau), t)
             key = ("x", subscripts)
         elif name.startswith("y#"):
             key = ("y", _slack_subscripts(name, NUM_Y_SLACKS, num_periods))
         elif name.startswith("s2#"):
-            key = ("s", _slack_subscripts(name, NUM_S_SLACKS, num_periods))
+            key = ("s2", _slack_subscripts(name, NUM_S_SLACKS, num_periods))
         else:
             raise ValueError(f"Unrecognized variable name in solution file: {name}")
 
@@ -175,11 +200,11 @@ def parse_sol_file(
             f"but got {len(values)}."
         )
     for subscripts in x_decl:
-        values.setdefault(("x", subscripts), 0.0)
+        values.setdefault(("x", subscripts), 0)
     for k in range(NUM_Y_SLACKS):
         for t in range(num_periods):
-            values.setdefault(("y", (k, t)), 0.0)
+            values.setdefault(("y", (k, t)), 0)
     for c in range(NUM_S_SLACKS):
         for t in range(num_periods):
-            values.setdefault(("s", (c, t)), 0.0)
+            values.setdefault(("s2", (c, t)), 0)
     return objective, values

--- a/ommx_quantum_benchmarks/qoblib/qoblib.py
+++ b/ommx_quantum_benchmarks/qoblib/qoblib.py
@@ -1575,10 +1575,16 @@ class Portfolio(BaseDataset):
         "Portfolio dataset in ommx format, originally provided by https://git.zib.de/qopt/qoblib-quantum-optimization-benchmarking-library/-/tree/main/06-portfolio?ref_type=heads."
     )
     model_names: list[str] = field(
-        default_factory=lambda: ["binary_quadratic", "quadratic_unconstrained"]
+        default_factory=lambda: [
+            "binary_quadratic_programming",
+            "unconstrained_quadratic_optimization",
+        ]
     )
     available_instances: dict[str, list[str]] = field(
-        default_factory=lambda: {"binary_quadratic": [], "quadratic_unconstrained": []}
+        default_factory=lambda: {
+            "binary_quadratic_programming": [],
+            "unconstrained_quadratic_optimization": [],
+        }
     )
 
 

--- a/tests/ommx_oblib/test_qoblib.py
+++ b/tests/ommx_oblib/test_qoblib.py
@@ -356,8 +356,8 @@ def test_portfolio():
 
     Check if
     - its name is "06_portfolio",
-    - its model_names is ["binary_quadratic", "quadratic_unconstrained"],
-    - its available_instances is dict whose key are "binary_quadratic" and "quadratic_unconstrained",
+    - its model_names is ["binary_quadratic_programming", "unconstrained_quadratic_optimization"],
+    - its available_instances is dict whose key are "binary_quadratic_programming" and "unconstrained_quadratic_optimization",
     - each value of its available_instances is a list of str,
     - the returned value of __call__ is a tuple of (ommx.v1.instance, ommx.v1.solution) using each values of its available_instances,
     - the evaluated solution with its instance and solution is the same as the original solution.
@@ -365,12 +365,15 @@ def test_portfolio():
     # - its name is "06_portfolio",
     dataset = Portfolio()
     assert dataset.name == "06_portfolio"
-    # - its model_names is ["binary_quadratic", "quadratic_unconstrained"],
-    assert dataset.model_names == ["binary_quadratic", "quadratic_unconstrained"]
-    # - its available_instances is dict whose key are "binary_quadratic" and "quadratic_unconstrained",
+    # - its model_names is ["binary_quadratic_programming", "unconstrained_quadratic_optimization"],
+    assert dataset.model_names == [
+        "binary_quadratic_programming",
+        "unconstrained_quadratic_optimization",
+    ]
+    # - its available_instances is dict whose key are "binary_quadratic_programming" and "unconstrained_quadratic_optimization",
     assert isinstance(dataset.available_instances, dict)
-    assert "binary_quadratic" in dataset.available_instances
-    assert "quadratic_unconstrained" in dataset.available_instances
+    assert "binary_quadratic_programming" in dataset.available_instances
+    assert "unconstrained_quadratic_optimization" in dataset.available_instances
     # - each value of its available_instances is a list of str,
     for model_name, instances in dataset.available_instances.items():
         assert isinstance(instances, list)


### PR DESCRIPTION
## Summary

This PR adds OMMX generation code for the **binary quadratic programming (BQP) model** of the QOBLIB `06-portfolio` dataset (multi-period portfolio optimization), corresponding to `06-portfolio/models/binary_quadratic_programming` in the [original QOBLIB repository](https://git.zib.de/qopt/qoblib-quantum-optimization-benchmarking-library/-/tree/main/06-portfolio). It is the constrained counterpart of the UQO model added in the companion PR #46 : the same multi-period portfolio objective, but with the capital limit and the number-of-assets limit kept as hard equality constraints instead of being folded into the objective as penalty terms.

## What's added

- `ommx_quantum_benchmarks/qoblib/06_portfolio/models/binary_quadratic_programming/`, following the structure of the existing model directories (e.g. `01_marketsplit`):
  - **`model.py`** — Reproduces the ZIMPL formulation (`bqp_u3_c10.zpl`): risk, return, transaction cost, short-selling cost, cash interest, and liquidation terms, plus the two per-day equality constraints (`capital_limit`, `asset_limit`). Written against the jijmodeling 2.x decorator API, so it runs with the current lockfile.
  - **`dat_reader.py`** — Reads `stock_prices.txt.gz` / `covariance_matrices.txt.gz` from the upstream instance directories and derives all coefficients with exact rational arithmetic (`fractions.Fraction`) and ZIMPL-style round-half-away-from-zero. Exact rationals are required: ZIMPL computes with GMP rationals, and a float64 reproduction is off by one on some a050 coefficients.
  - **`sol_reader.py`** — Parses the named Gurobi-format solutions under `solutions/bqp`, decoding ZIMPL's mangled LP variable names (e.g. `x$AAPL#1#_1#0@a`) via the `@hex` declaration-order index.
  - **`ommx_create.py`** — Batch-converts every instance directory × 8 lambda values into `.ommx` artifacts named after the upstream LP files (e.g. `bqp_a010_t10_orig_b004_l0.001`), attaching the best-known solution and verifying it against the instance before packaging.
- Rename of `Portfolio.model_names` in `qoblib.py` (`binary_quadratic` → `binary_quadratic_programming`, `quadratic_unconstrained` → `unconstrained_quadratic_optimization`) and the corresponding update of `test_portfolio`.

## What this enables

- OMMX artifacts for the QOBLIB portfolio BQP benchmark can now be generated and uploaded to the GitHub Container Registry with the standard workflow described in `upload_guide.md` (copy upstream `instances/` and `solutions/`, run `ommx_create.py`, upload via the notebook).
- Each artifact bundles the instance (3110 variables / 20 constraints for a050_t10; 710 / 20 for a010_t10) together with the best-known solution and its objective, so users will be able to load a constrained portfolio instance and a reference solution in one call via `Portfolio()("binary_quadratic_programming", ...)` once uploaded.
- Together with the UQO branch, both upstream formulations of `06-portfolio` (constrained BQP and QUBO) become available in OMMX format, allowing direct comparison of classical and quantum-oriented solvers on identical data.

## Test plan

- [x] Converted all locally testable combinations (a010/a050 × t10/t15 × all 8 lambda values, 24 instances) from upstream data: every evaluated solution **exactly matches** the `# Objective value` header of the corresponding Gurobi solution file (which equals the best-known values published in the upstream solutions README) and satisfies **all equality constraints** (`feasible=True`).
- [x] Round-trip check: re-loaded a generated `.ommx` artifact (`bqp_a050_t10_orig_b020_l0.001`), confirmed 3110 decision variables, 20 constraints, and that re-evaluating the stored solution state reproduces the stored objective (−206239).
- [x] `uv run pytest tests/ommx_oblib/test_qoblib.py::test_portfolio` passes with the renamed model names.
- [ ] After merge: run the full conversion over all 16 instance directories and upload via the uploader notebook, then populate `Portfolio.available_instances`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)